### PR TITLE
fix: 🐛 disable `typescript-eslint/no-unsafe-` in tests

### DIFF
--- a/src/configs/__snapshots__/typescript.spec.ts.snap
+++ b/src/configs/__snapshots__/typescript.spec.ts.snap
@@ -8905,5 +8905,19 @@ If your function does not access \`this\`, you can annotate it with \`this: void
       "@typescript-eslint/use-unknown-in-catch-callback-variable": "off",
     },
   },
+  {
+    "files": [
+      "**/__tests__/**/*.?([cm])[jt]s?(x)",
+      "**/*.spec.?([cm])[jt]s?(x)",
+      "**/*.test.?([cm])[jt]s?(x)",
+      "**/*.bench.?([cm])[jt]s?(x)",
+      "**/*.benchmark.?([cm])[jt]s?(x)",
+    ],
+    "name": "jimmy.codes/typescript/testing",
+    "rules": {
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+    },
+  },
 ]
 `;

--- a/src/configs/typescript.ts
+++ b/src/configs/typescript.ts
@@ -2,7 +2,7 @@ import { config, configs } from "typescript-eslint";
 
 import type { TypescriptOptions } from "../types";
 
-import { GLOB_JS, GLOB_JSX } from "../constants";
+import { GLOB_JS, GLOB_JSX, GLOB_TESTS } from "../constants";
 
 const typescriptConfig = (options: TypescriptOptions) => {
   return config(
@@ -41,6 +41,14 @@ const typescriptConfig = (options: TypescriptOptions) => {
     {
       files: [GLOB_JS, GLOB_JSX],
       ...configs.disableTypeChecked,
+    },
+    {
+      files: GLOB_TESTS,
+      name: "jimmy.codes/typescript/testing",
+      rules: {
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+      },
     },
   );
 };


### PR DESCRIPTION
closes #68 