### PR TITLE
Fix add agent files to ignores

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -48,7 +48,8 @@
     "vinxi",
     "vitepress",
     "vitest",
-    "wagoid"
+    "wagoid",
+    "worktrees"
   ],
   "ignorePaths": [
     "node_modules",

--- a/src/globs.ts
+++ b/src/globs.ts
@@ -74,6 +74,9 @@ export const GLOB_IGNORES = [
   "**/app.config.timestamp_*.js",
   "**/.tanstack",
   "**/.nitro",
+  "**/.agents",
+  "**/.claude",
+  "**/.worktrees",
 
   "**/CHANGELOG*.md",
   "**/*.min.*",

--- a/src/rules/__snapshots__/vitest.spec.ts.snap
+++ b/src/rules/__snapshots__/vitest.spec.ts.snap
@@ -74,6 +74,7 @@ exports[`should create vitest rules 1`] = `
   "vitest/require-local-test-context-for-concurrent-snapshots": "error",
   "vitest/require-to-throw-message": "error",
   "vitest/require-top-level-describe": "off",
+  "vitest/unbound-method": "off",
   "vitest/valid-describe-callback": "error",
   "vitest/valid-expect": "error",
   "vitest/valid-expect-in-promise": "error",

--- a/src/rules/vitest.spec.ts
+++ b/src/rules/vitest.spec.ts
@@ -1,7 +1,29 @@
+import { isPackageExists } from "local-pkg";
+
 import { vitestRules } from "./vitest";
+
+vi.mock("local-pkg");
 
 test("should create vitest rules", async () => {
   await expect(vitestRules()).resolves.toMatchSnapshot();
+});
+
+test("should enable typescript-aware unbound-method rules with typescript", async () => {
+  vi.mocked(isPackageExists).mockImplementation((name) => {
+    return name === "typescript";
+  });
+
+  const rules = await vitestRules();
+
+  expect(rules["vitest/unbound-method"]).toBe("error");
+  expect(rules["@typescript-eslint/unbound-method"]).toBe("off");
+});
+
+test("should disable vitest/unbound-method without typescript", async () => {
+  const rules = await vitestRules();
+
+  expect(rules["vitest/unbound-method"]).toBe("off");
+  expect(rules["@typescript-eslint/unbound-method"]).toBeUndefined();
 });
 
 test("should enforce importing vitest globals when 'explicit' option is used", async () => {

--- a/src/rules/vitest.ts
+++ b/src/rules/vitest.ts
@@ -1,9 +1,11 @@
 import type { Rules, VitestOptions } from "../types";
 
+import { hasTypescript } from "../utils/has-dependency";
 import { unwrapDefault } from "../utils/interop-default";
 
 export const vitestRules = async (options?: VitestOptions) => {
   const vitestPlugin = await unwrapDefault(import("@vitest/eslint-plugin"));
+  const isUsingTypescript = hasTypescript();
 
   return {
     ...vitestPlugin.configs.recommended.rules,
@@ -70,7 +72,7 @@ export const vitestRules = async (options?: VitestOptions) => {
     "vitest/require-hook": "error",
     "vitest/require-to-throw-message": "error",
     "vitest/require-top-level-describe": "off",
-    // "vitest/unbound-method": "off", // requires typescript, missing https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/unbound-method.md
+    "vitest/unbound-method": isUsingTypescript ? "error" : "off",
     "vitest/valid-title": [
       "error",
       {
@@ -80,6 +82,9 @@ export const vitestRules = async (options?: VitestOptions) => {
       },
     ],
     "vitest/warn-todo": "warn",
+    ...(isUsingTypescript
+      ? { "@typescript-eslint/unbound-method": "off" as const }
+      : {}),
     ...options?.overrides,
   } satisfies Rules;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated spellcheck configuration with additional accepted words.

* **New Features**
  * Added ignore patterns for `.agents`, `.claude`, and `.worktrees` directories.

* **Enhancements**
  * Vitest lint rules now automatically detect and configure based on TypeScript availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->